### PR TITLE
fix: prevent duplicate GitHub Actions workflows on PR to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   test-and-coverage:
@@ -73,13 +71,14 @@ jobs:
         fi
         
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage/lcov.info
+        files: ./coverage/lcov.info
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true
         verbose: true
+        token: ${{ secrets.CODECOV_TOKEN }}
       continue-on-error: true
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -131,13 +131,14 @@ jobs:
           }
           
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage/lcov.info
+        files: ./coverage/lcov.info
         flags: pull-request
         name: codecov-pr
         fail_ci_if_error: false
         verbose: true
+        token: ${{ secrets.CODECOV_TOKEN }}
       if: false  # Disabled - only upload coverage on main branch updates
 
   build-check:
@@ -168,3 +169,11 @@ jobs:
           echo "❌ Build failed - dist directory not found"
           exit 1
         fi
+        
+    - name: Run security audit
+      run: npm audit --audit-level=moderate
+      continue-on-error: true
+      
+    - name: Check for known vulnerabilities
+      run: npm audit --audit-level=high
+      continue-on-error: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,9 @@ module.exports = {
     '**/?(*.)+(spec|test).ts',
   ],
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: '<rootDir>/tests/tsconfig.json',
+    }],
   },
   collectCoverageFrom: [
     'src/**/*.ts',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,5 +26,8 @@ export * from './memory';
 // Versioning system types
 export * from './versioning';
 
+// Indexing system types
+export * from './indexing';
+
 // Performance configuration types
 // export * from './performance-config'; // Commented out due to naming conflicts

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -20,10 +20,22 @@
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "allowUnusedLabels": false,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "baseUrl": "../src",
+    "paths": {
+      "@/*": ["*"],
+      "@/types/*": ["types/*"],
+      "@/core/*": ["core/*"],
+      "@/parsers/*": ["parsers/*"],
+      "@/analyzers/*": ["analyzers/*"],
+      "@/utils/*": ["utils/*"],
+      "@/config/*": ["config/*"],
+      "@/indexing/*": ["indexing/*"]
+    }
   },
   "include": [
-    "**/*.ts"
+    "**/*.ts",
+    "../src/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
- Remove pull_request trigger from ci.yml workflow
- ci.yml now only runs on push to main (for deployment)
- pr-validation.yml handles all PR validation with comprehensive checks
- Add security audit checks to PR validation workflow
- Eliminates duplicate workflow runs when creating PRs to main